### PR TITLE
Add player targeting for Sleepless entity

### DIFF
--- a/src/main/java/net/mcreator/sleepless/entity/SleeplessEntity.java
+++ b/src/main/java/net/mcreator/sleepless/entity/SleeplessEntity.java
@@ -18,10 +18,12 @@ import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.entity.monster.Monster;
 import net.minecraft.world.entity.ai.goal.target.HurtByTargetGoal;
+import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
 import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
 import net.minecraft.world.entity.ai.goal.RandomLookAroundGoal;
 import net.minecraft.world.entity.ai.goal.MeleeAttackGoal;
 import net.minecraft.world.entity.ai.goal.FloatGoal;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.SpawnPlacements;
@@ -96,10 +98,11 @@ public class SleeplessEntity extends Monster implements GeoEntity {
 				return this.mob.getBbWidth() * this.mob.getBbWidth() + entity.getBbWidth();
 			}
 		});
-		this.goalSelector.addGoal(2, new RandomStrollGoal(this, 1));
-		this.targetSelector.addGoal(3, new HurtByTargetGoal(this));
-		this.goalSelector.addGoal(4, new RandomLookAroundGoal(this));
-		this.goalSelector.addGoal(5, new FloatGoal(this));
+               this.goalSelector.addGoal(2, new RandomStrollGoal(this, 1));
+               this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, true));
+               this.targetSelector.addGoal(3, new HurtByTargetGoal(this));
+               this.goalSelector.addGoal(4, new RandomLookAroundGoal(this));
+               this.goalSelector.addGoal(5, new FloatGoal(this));
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
- make the Sleepless entity actively target players

## Testing
- `./gradlew build` *(fails: could not complete build)*

------
https://chatgpt.com/codex/tasks/task_e_68539a8b4614833180bec4eddb1a8709