### PR TITLE
Fix dimension type format to prevent world load crash

### DIFF
--- a/src/main/resources/data/sleepless/dimension_type/nightmare.json
+++ b/src/main/resources/data/sleepless/dimension_type/nightmare.json
@@ -12,7 +12,11 @@
   "coordinate_scale": 1.0,
   "fixed_time": 18000,
   "effects": "minecraft:the_end",
-  "monster_spawn_light_level": 0,
+  "monster_spawn_block_light_limit": 0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:constant",
+    "value": 0
+  },
   "min_y": 0,
   "height": 256,
   "infiniburn": "minecraft:infiniburn_end",


### PR DESCRIPTION
## Summary
- correct `monster_spawn_light_level` format for `sleepless:nightmare`

## Testing
- `./gradlew build` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857bdb3819c8331b04cca953eb4a086