### PR TITLE
Fix Sleepless despawn timer and door range

### DIFF
--- a/src/main/java/net/mcreator/sleepless/entity/SleeplessEntity.java
+++ b/src/main/java/net/mcreator/sleepless/entity/SleeplessEntity.java
@@ -54,10 +54,11 @@ public class SleeplessEntity extends Monster implements GeoEntity {
 	public static final EntityDataAccessor<String> ANIMATION = SynchedEntityData.defineId(SleeplessEntity.class, EntityDataSerializers.STRING);
 	public static final EntityDataAccessor<String> TEXTURE = SynchedEntityData.defineId(SleeplessEntity.class, EntityDataSerializers.STRING);
 	private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
-	private boolean swinging;
-	private boolean lastloop;
-	private long lastSwing;
-	public String animationprocedure = "empty";
+        private boolean swinging;
+        private boolean lastloop;
+        private long lastSwing;
+        public String animationprocedure = "empty";
+        private int lookedAtTicks;
 
 	public SleeplessEntity(PlayMessages.SpawnEntity packet, Level world) {
 		this(SleeplessModEntities.SLEEPLESS.get(), world);
@@ -147,11 +148,20 @@ public class SleeplessEntity extends Monster implements GeoEntity {
                 super.baseTick();
                 this.refreshDimensions();
                 if (!level().isClientSide()) {
+                        boolean someoneLooking = false;
                         for (Player player : level().players()) {
                                 if (player.distanceTo(this) < 16 && isPlayerLooking(player)) {
-                                        this.remove(RemovalReason.DISCARDED);
+                                        someoneLooking = true;
                                         break;
                                 }
+                        }
+                        if (someoneLooking) {
+                                lookedAtTicks++;
+                                if (lookedAtTicks > 40) {
+                                        this.remove(RemovalReason.DISCARDED);
+                                }
+                        } else {
+                                lookedAtTicks = 0;
                         }
                 }
        }

--- a/src/main/java/net/mcreator/sleepless/util/DoorPortalHandler.java
+++ b/src/main/java/net/mcreator/sleepless/util/DoorPortalHandler.java
@@ -44,7 +44,7 @@ public class DoorPortalHandler {
         // Only trigger when opening a closed door
         if (state.getValue(DoorBlock.OPEN))
             return;
-        List<SleeplessEntity> nearby = event.getLevel().getEntitiesOfClass(SleeplessEntity.class, player.getBoundingBox().inflate(10));
+        List<SleeplessEntity> nearby = event.getLevel().getEntitiesOfClass(SleeplessEntity.class, player.getBoundingBox().inflate(20));
         if (nearby.isEmpty())
             return;
         CompoundTag tag = player.getPersistentData();


### PR DESCRIPTION
## Summary
- delay Sleepless despawn to prevent instant disappearance when looked at
- enlarge door portal range for better reliability

## Testing
- `./gradlew test` *(fails: download steps hang)*

------
https://chatgpt.com/codex/tasks/task_e_68587910192c8331b79f11a3bb0a9290