### PR TITLE
Prevent natural despawn

### DIFF
--- a/src/main/java/net/mcreator/sleepless/entity/SleeplessEntity.java
+++ b/src/main/java/net/mcreator/sleepless/entity/SleeplessEntity.java
@@ -117,10 +117,15 @@ public class SleeplessEntity extends Monster implements GeoEntity {
 		return MobType.UNDEFINED;
 	}
 
-	@Override
-	public boolean removeWhenFarAway(double distanceToClosestPlayer) {
-		return false;
-	}
+        @Override
+        public boolean removeWhenFarAway(double distanceToClosestPlayer) {
+                return false;
+        }
+
+       @Override
+       public void checkDespawn() {
+               // Prevent natural despawn logic
+       }
 
 	@Override
 	public SoundEvent getHurtSound(DamageSource ds) {


### PR DESCRIPTION
## Summary
- keep Sleepless entity alive by overriding `checkDespawn`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6858f796de2c8331a5c7ee56b6390b32