### PR TITLE
Fix hub placement and controlled Sleepless spawns

### DIFF
--- a/src/main/resources/data/sleepless/forge/biome_modifier/sleepless_biome_modifier.json
+++ b/src/main/resources/data/sleepless/forge/biome_modifier/sleepless_biome_modifier.json
@@ -5,8 +5,8 @@
   },
   "spawners": {
     "type": "sleepless:sleepless",
-    "weight": 20,
-    "minCount": 4,
-    "maxCount": 4
+    "weight": 0,
+    "minCount": 1,
+    "maxCount": 1
   }
 }


### PR DESCRIPTION
## Summary
- ensure the hub structure only generates once and log its placement
- disable natural Sleepless spawning via biome modifier
- spawn a single Sleepless when a player first enters the dimension with debugging info

## Testing
- `./gradlew clean build -x test` *(fails: daemon fork step didn't finish)*

------
https://chatgpt.com/codex/tasks/task_e_685cd088d520833180a38c37d721be75