### PR TITLE
Fix player spawn inside Sleepless hub

### DIFF
--- a/src/main/java/net/mcreator/sleepless/command/DoorSpawnCommand.java
+++ b/src/main/java/net/mcreator/sleepless/command/DoorSpawnCommand.java
@@ -1,0 +1,49 @@
+package net.mcreator.sleepless.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import net.mcreator.sleepless.SleeplessMod;
+import net.mcreator.sleepless.util.SleeplessDimensionEvents;
+
+import net.minecraft.core.BlockPos;
+
+/**
+ * Command to teleport the executing player to the same location the door
+ * portal would send them in the Sleepless dimension. Useful for testing
+ * structure generation and spawn logic without using a door.
+ */
+@Mod.EventBusSubscriber(modid = SleeplessMod.MODID)
+public class DoorSpawnCommand {
+
+    @SubscribeEvent
+    public static void register(RegisterCommandsEvent event) {
+        CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+        dispatcher.register(Commands.literal("doorspawn")
+                .requires(cs -> cs.hasPermission(2))
+                .executes(ctx -> execute(ctx.getSource())));
+    }
+
+    private static int execute(CommandSourceStack source) throws CommandSyntaxException {
+        ServerPlayer player = source.getPlayerOrException();
+        ServerLevel level = player.server.getLevel(SleeplessDimensionEvents.dimensionKey());
+        if (level == null) {
+            source.sendFailure(Component.literal("Sleepless dimension missing"));
+            return 0;
+        }
+        SleeplessDimensionEvents.ensureHubPlaced(level);
+        BlockPos spawn = SleeplessDimensionEvents.adjustSpawnPos(level);
+        player.teleportTo(level, SleeplessDimensionEvents.getSpawnVec().x, spawn.getY(),
+                SleeplessDimensionEvents.getSpawnVec().z, player.getYRot(), player.getXRot());
+        source.sendSuccess(() -> Component.literal("Teleported to Sleepless door spawn"), true);
+        return 1;
+    }
+}

--- a/src/main/java/net/mcreator/sleepless/util/DoorPortalHandler.java
+++ b/src/main/java/net/mcreator/sleepless/util/DoorPortalHandler.java
@@ -20,6 +20,7 @@ import net.minecraftforge.fml.common.Mod;
 
 import net.mcreator.sleepless.SleeplessMod;
 import net.mcreator.sleepless.entity.SleeplessEntity;
+import net.mcreator.sleepless.util.SleeplessDimensionEvents;
 
 import java.util.List;
 
@@ -108,6 +109,7 @@ public class DoorPortalHandler {
                     ResourceKey<Level> key = ResourceKey.create(Registries.DIMENSION, new ResourceLocation(SleeplessMod.MODID, "sleepless_dimension"));
                     ServerLevel target = sp.server.getLevel(key);
                     if (target != null) {
+                        SleeplessDimensionEvents.ensureHubPlaced(target);
                         tag.putInt(RETURN_X, doorPos.getX());
                         tag.putInt(RETURN_Y, doorPos.getY());
                         tag.putInt(RETURN_Z, doorPos.getZ());


### PR DESCRIPTION
## Summary
- ensure hub placement before players teleport in
- expose `ensureHubPlaced` helper for other handlers
- always place hub regardless of existing terrain
- add `/doorspawn` command to teleport to the hub for testing

## Testing
- `./gradlew help --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_685df375f6ac83319eeb3506b3a04d47